### PR TITLE
Fix wrong returns and use proper WP_Error

### DIFF
--- a/includes/core/apps/wordpress-app/tabs-server/logs.php
+++ b/includes/core/apps/wordpress-app/tabs-server/logs.php
@@ -175,7 +175,7 @@ class WPCD_WORDPRESS_TABS_SERVER_LOGS extends WPCD_WORDPRESS_TABS {
 	 * @param int    $id         The postID of the server cpt.
 	 * @param string $action     The action to be performed (this matches the string required in the bash scripts if bash scripts are used ).
 	 *
-	 * @return boolean  success/failure/other
+	 * @return bool|\WP_Error  success/failure/other
 	 */
 	private function do_server_log_actions( $id, $action ) {
 

--- a/includes/core/apps/wordpress-app/tabs/logs.php
+++ b/includes/core/apps/wordpress-app/tabs/logs.php
@@ -177,7 +177,7 @@ class WPCD_WORDPRESS_TABS_SITE_LOGS extends WPCD_WORDPRESS_TABS {
 		$instance = $this->get_app_instance_details( $id );
 
 		if ( is_wp_error( $instance ) ) {
-			return $result;
+			return new \WP_Error( sprintf( __( 'Unable to execute this request because we cannot get the instance details for action %s', 'wpcd' ), $action ) );
 		}
 
 		/* Grab the arguments sent from the front-end JS */

--- a/includes/core/apps/wordpress-app/tabs/sftp.php
+++ b/includes/core/apps/wordpress-app/tabs/sftp.php
@@ -469,7 +469,7 @@ class WPCD_WORDPRESS_TABS_SFTP extends WPCD_WORDPRESS_TABS {
 		$instance = $this->get_app_instance_details( $id );
 
 		if ( is_wp_error( $instance ) ) {
-			return $result;
+			return new \WP_Error( sprintf( __( 'Unable to execute this request because we cannot get the instance details for action %s', 'wpcd' ), $action ) );
 		}
 
 		/* Grab the arguments sent from the front-end JS */

--- a/includes/core/apps/wordpress-app/tabs/site-system-users.php
+++ b/includes/core/apps/wordpress-app/tabs/site-system-users.php
@@ -286,7 +286,7 @@ class WPCD_WORDPRESS_TABS_SITE_SYSTEM_USERS extends WPCD_WORDPRESS_TABS {
 		$instance = $this->get_app_instance_details( $id );
 
 		if ( is_wp_error( $instance ) ) {
-			return $result;
+			return new \WP_Error( sprintf( __( 'Unable to execute this request because we cannot get the instance details for action %s', 'wpcd' ), $action ) );
 		}
 
 		/* Grab the arguments sent from the front-end JS */


### PR DESCRIPTION
This is a minor one, but since I've come across it, why not fix it?