### PR TITLE
Support for Custom S3 Endpoints

### DIFF
--- a/includes/core/apps/wordpress-app/class-wordpress-app-settings.php
+++ b/includes/core/apps/wordpress-app/class-wordpress-app-settings.php
@@ -1767,6 +1767,15 @@ class WORDPRESS_APP_SETTINGS extends WPCD_APP_SETTINGS {
 				'size'    => 60,
 			),
 			array(
+				'id'      => 'wordpress_app_s3_endpoint',
+				'type'    => 'text',
+				'name'    => __( 'S3 Endpoint URL', 'wpcd' ),
+				'tooltip' => __( 'Set this if you want to use an alternative S3-compatible service.', 'wpcd' ),
+				'tab'     => 'wordpress-app-backup',
+				'std'     => wpcd_get_option( 'wordpress_app_s3_endpoint' ),
+				'size'    => 60,
+			),
+			array(
 				'id'   => 'wordpress_app_backup_warning',
 				'type' => 'custom_html',
 				'std'  => __( 'Warning! If you are using our SELL SERVERS WITH WOOCOMMERCE premium option, do NOT set these defaults. Otherwise all servers, including your customer servers, will be able to get these. Since your customers might be able to log into their own servers, they will be able to view these credentials. Instead, set them on each server as needed.  See our WOOCOMMERCE documentation for more information or contact our support team with your questions.', 'wpcd' ),

--- a/includes/core/apps/wordpress-app/scripts/v1/backup_restore.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/backup_restore.txt
@@ -3,7 +3,7 @@ echo "done" && {
 	sudo -E wget --no-check-certificate -O ##SCRIPT_COMMON_NAME## ##SCRIPT_COMMON_URL## &&
 	sudo -E dos2unix ##SCRIPT_COMMON_NAME## &&	
     sudo -E wget --no-check-certificate -O ##SCRIPT_NAME## ##SCRIPT_URL## &&
-    export action=##ACTION## domain=##DOMAIN## site=##DOMAIN## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## aws_bucket_name=##AWS_BUCKET_NAME## aws_region=##AWS_REGION## overwrite=##OVERWRITE## backup=##BACKUP## &&
+    export action=##ACTION## domain=##DOMAIN## site=##DOMAIN## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## aws_bucket_name=##AWS_BUCKET_NAME## aws_region=##AWS_REGION## s3_endpoint=##S3_ENDPOINT## overwrite=##OVERWRITE## backup=##BACKUP## &&
     sudo -E dos2unix ##SCRIPT_NAME## &&
     sudo -E bash ##SCRIPT_NAME## >> ##SCRIPT_LOGS##.log.intermed 2>&1 &&
     sudo -E mv ##SCRIPT_LOGS##.log.intermed ##SCRIPT_LOGS##.log.done &&

--- a/includes/core/apps/wordpress-app/scripts/v1/backup_restore_delete_and_prune.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/backup_restore_delete_and_prune.txt
@@ -3,7 +3,7 @@ echo "done" && {
 	sudo -E wget --no-check-certificate -O ##SCRIPT_COMMON_NAME## ##SCRIPT_COMMON_URL## &&
 	sudo -E dos2unix ##SCRIPT_COMMON_NAME## &&	
     sudo -E wget --no-check-certificate -O ##SCRIPT_NAME## ##SCRIPT_URL## &&
-    export action=##ACTION## domain=##DOMAIN## site=##DOMAIN## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## aws_bucket_name=##AWS_BUCKET_NAME## aws_region=##AWS_REGION## days=##DAYS## confirmation=##CONFIRMATION## &&
+    export action=##ACTION## domain=##DOMAIN## site=##DOMAIN## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## aws_bucket_name=##AWS_BUCKET_NAME## aws_region=##AWS_REGION## s3_endpoint=##S3_ENDPOINT## days=##DAYS## confirmation=##CONFIRMATION## &&
     sudo -E dos2unix ##SCRIPT_NAME## &&
     sudo -E bash ##SCRIPT_NAME## >> ##SCRIPT_LOGS##.log.intermed 2>&1 &&
     sudo -E mv ##SCRIPT_LOGS##.log.intermed ##SCRIPT_LOGS##.log.done &&

--- a/includes/core/apps/wordpress-app/scripts/v1/backup_restore_delete_and_prune_server.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/backup_restore_delete_and_prune_server.txt
@@ -3,6 +3,6 @@ sudo -E \rm -f ##SCRIPT_NAME## &&
 sudo -E wget --no-check-certificate -O ##SCRIPT_COMMON_NAME## ##SCRIPT_COMMON_URL## &&
 sudo -E dos2unix ##SCRIPT_COMMON_NAME## &&
 sudo -E wget --no-check-certificate -O ##SCRIPT_NAME## ##SCRIPT_URL## &&
-export action=##ACTION## domain=##DOMAIN## site=##DOMAIN## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## aws_bucket_name=##AWS_BUCKET_NAME## aws_region=##AWS_REGION## days=##DAYS## confirmation=##CONFIRMATION## &&
+export action=##ACTION## domain=##DOMAIN## site=##DOMAIN## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## aws_bucket_name=##AWS_BUCKET_NAME## aws_region=##AWS_REGION## s3_endpoint=##S3_ENDPOINT## days=##DAYS## confirmation=##CONFIRMATION## confirmation=##CONFIRMATION## &&
 sudo -E dos2unix ##SCRIPT_NAME## &&
 sudo -E bash ##SCRIPT_NAME##

--- a/includes/core/apps/wordpress-app/scripts/v1/backup_restore_save_credentials.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/backup_restore_save_credentials.txt
@@ -2,6 +2,6 @@ cd ~ &&
 sudo -E wget --no-check-certificate -O ##SCRIPT_COMMON_NAME## ##SCRIPT_COMMON_URL## &&
 sudo -E dos2unix ##SCRIPT_COMMON_NAME## &&
 sudo -E wget --no-check-certificate -O ##SCRIPT_NAME## ##SCRIPT_URL## &&
-export action=##ACTION## domain=##DOMAIN## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## aws_region=##AWS_REGION## &&
+export action=##ACTION## domain=##DOMAIN## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## aws_region=##AWS_REGION## s3_endpoint=##S3_ENDPOINT## &&
 sudo -E dos2unix ##SCRIPT_NAME## &&
 sudo -E bash ##SCRIPT_NAME##

--- a/includes/core/apps/wordpress-app/scripts/v1/backup_restore_schedule.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/backup_restore_schedule.txt
@@ -2,6 +2,6 @@ cd ~ &&
 sudo -E wget --no-check-certificate -O ##SCRIPT_COMMON_NAME## ##SCRIPT_COMMON_URL## &&
 sudo -E dos2unix ##SCRIPT_COMMON_NAME## &&
 sudo -E wget --no-check-certificate -O ##SCRIPT_NAME## ##SCRIPT_URL## &&
-export action=##ACTION## domain=##DOMAIN## job=##DOMAIN## days=##AUTO_BACKUP_RETENTION_DAYS## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## bucket=##AWS_BUCKET_NAME## aws_region=##AWS_REGION## s3_sync_delete_parm=##S3_SYNC_DELETE_PARM## callback_domain=##CALLBACK_DOMAIN## &&
+export action=##ACTION## domain=##DOMAIN## job=##DOMAIN## days=##AUTO_BACKUP_RETENTION_DAYS## aws_access_key_id=##AWS_ACCESS_KEY_ID## aws_secret_access_key=##AWS_SECRET_ACCESS_KEY## bucket=##AWS_BUCKET_NAME## aws_region=##AWS_REGION## s3_endpoint=##S3_ENDPOINT## s3_sync_delete_parm=##S3_SYNC_DELETE_PARM## callback_domain=##CALLBACK_DOMAIN## &&
 sudo -E dos2unix ##SCRIPT_NAME## &&
 sudo -E bash ##SCRIPT_NAME##

--- a/includes/core/apps/wordpress-app/scripts/v1/raw/08-backup.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/raw/08-backup.txt
@@ -163,11 +163,11 @@ then
 	mysqldump $mysql_db | gzip -9 > /root/.wp-backup/$domain/"$domain"_"$date"_db.gz
 	# upload to s3
 	echo "=>Uploading files to Amazon S3..."
-	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials aws s3 cp /root/.wp-backup/$domain/"$domain"_"$date"_fs.tar.gz s3://$aws_bucket_name/$domain/"$domain"_"$date"_fs.tar.gz --sse --only-show-errors
+	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials aws s3 cp /root/.wp-backup/$domain/"$domain"_"$date"_fs.tar.gz s3://$aws_bucket_name/$domain/"$domain"_"$date"_fs.tar.gz --sse --only-show-errors ${s3_endpoint:+--endpoint-url=$s3_endpoint}
 	echo "=>Uploading $g_webserver_type configuration to Amazon S3..."
-	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials aws s3 cp /root/.wp-backup/$domain/"$domain"_"$date"_"${g_webserver_type}".tar.gz s3://$aws_bucket_name/$domain/"$domain"_"$date"_"${g_webserver_type}".tar.gz --sse --only-show-errors
+	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials aws s3 cp /root/.wp-backup/$domain/"$domain"_"$date"_"${g_webserver_type}".tar.gz s3://$aws_bucket_name/$domain/"$domain"_"$date"_"${g_webserver_type}".tar.gz --sse --only-show-errors ${s3_endpoint:+--endpoint-url=$s3_endpoint}
 	echo "=>Uploading database to to Amazon S3..."
-	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials aws s3 cp /root/.wp-backup/$domain/"$domain"_"$date"_db.gz s3://$aws_bucket_name/$domain/"$domain"_"$date"_db.gz --sse --only-show-errors
+	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials aws s3 cp /root/.wp-backup/$domain/"$domain"_"$date"_db.gz s3://$aws_bucket_name/$domain/"$domain"_"$date"_db.gz --sse --only-show-errors ${s3_endpoint:+--endpoint-url=$s3_endpoint}
 
 	# check if the database was backed up correctly
 	echo "Verifying database backup..."

--- a/includes/core/apps/wordpress-app/scripts/v1/raw/08-backup.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/raw/08-backup.txt
@@ -443,7 +443,7 @@ do
 		find /root/.wp-backup/$domain/ -type f -mtime +$days -exec rm -f {} \;
 	fi
 	# sync to s3
-	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials /usr/local/bin/aws s3 sync /root/.wp-backup/$domain/ s3://$bucket/$domain --$s3_sync_delete_parm && echo "$(date) $domain backup successful" >> /var/log/wp-backup.log || echo "$(date) $domain backup failed" >> /var/log/wp-backup.log
+	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials /usr/local/bin/aws s3 sync /root/.wp-backup/$domain/ s3://$bucket/$domain --$s3_sync_delete_parm ${s3_endpoint:+--endpoint-url=$s3_endpoint} && echo "$(date) $domain backup successful" >> /var/log/wp-backup.log || echo "$(date) $domain backup failed" >> /var/log/wp-backup.log
 	# Callback to notify that backup is completed.
 	if [[ -n "$callback_domain" ]]
 	then
@@ -590,7 +590,7 @@ do
 		find /root/.wp-backup/$line/ -type f -mtime +$1 -exec rm -f {} \;
 	fi
 	# sync to s3
-	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials /usr/local/bin/aws s3 sync /root/.wp-backup/$line/ s3://$2/$line --$4 && echo "$(date) $domain backup successful" >> /var/log/wp-full-backup.log || echo "$(date) $domain backup failed" >> /var/log/wp-full-backup.log
+	AWS_SHARED_CREDENTIALS_FILE=$user_home/.aws/credentials /usr/local/bin/aws s3 sync /root/.wp-backup/$line/ s3://$2/$line --$4 ${s3_endpoint:+--endpoint-url=$s3_endpoint} && echo "$(date) $domain backup successful" >> /var/log/wp-full-backup.log || echo "$(date) $domain backup failed" >> /var/log/wp-full-backup.log
 	# Callback to notify that backup is completed.
 	# $5 should be the callback domain var...
 	if [[ -n "$5" ]]

--- a/includes/core/apps/wordpress-app/scripts/v1/raw/environment variables.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/raw/environment variables.txt
@@ -107,6 +107,7 @@ For $action = "backup", the following variables are needed:
 $domain = domain of the website to create a backup from (example: myblog.com)
 $aws_bucket_name = AWS S3 bucket name where you want to save the backup
 optional: $callback_domain - the domain to report the start and end of the backups. We had to hardcode the callback url so only need the domain.
+optional: $s3_endpoint - set if using an alternative s3-compatible service to AWS
 
 For $action = "restore", the following variables are needed:
 $site = domain of the website to restore (example: myblog.com)

--- a/includes/core/apps/wordpress-app/tabs-server/backup.php
+++ b/includes/core/apps/wordpress-app/tabs-server/backup.php
@@ -224,6 +224,20 @@ class WPCD_WORDPRESS_TABS_SERVER_BACKUP extends WPCD_WORDPRESS_TABS {
 			'size'       => 10,
 		);
 		$fields[] = array(
+			'name'       => __( 'S3 Endpoint URL', 'wpcd' ),
+			'id'         => 'wpcd_app_s3_endpoint',
+			'tab'        => 'server_backup',
+			'type'       => 'text',
+			'tooltip'    => __( 'Set this if you want to use an alternative S3-compatible service.', 'wpcd' ),
+			'save_field' => false,
+			'attributes' => array(
+				// the key of the field (the key goes in the request).
+				'data-wpcd-name' => 's3_endpoint',
+			),
+			'std'        => get_post_meta( $id, 'wpcd_wpapp_backup_s3_endpoint', true ),
+			'size'       => 90,
+		);
+		$fields[] = array(
 			'id'         => 'wpcd_app_action_change_cred',
 			'name'       => '',
 			'tab'        => 'server_backup',
@@ -607,6 +621,12 @@ class WPCD_WORDPRESS_TABS_SERVER_BACKUP extends WPCD_WORDPRESS_TABS {
 			// Get the one from the global settings screen...
 			$creds['aws_region'] = escapeshellarg( wpcd_get_option( 'wordpress_app_aws_default_region' ) );
 		}
+		if ( ! empty( $args['s3_endpoint'] ) ) {
+			$creds['s3_endpoint'] = escapeshellarg( $args['s3_endpoint'] );
+		} else {
+			// Get the one from the global settings screen...
+			$creds['s3_endpoint'] = escapeshellarg( wpcd_get_option( 'wordpress_app_s3_endpoint' ) );
+		}
 
 		// If at this point both the credential fields are still blank, error out.
 		if ( empty( $creds['aws_access_key_id'] ) || empty( $creds['aws_secret_access_key'] ) || empty( $creds['aws_region'] ) ) {
@@ -649,6 +669,7 @@ class WPCD_WORDPRESS_TABS_SERVER_BACKUP extends WPCD_WORDPRESS_TABS {
 			update_post_meta( $server_id, 'wpcd_wpapp_backup_aws_secret', self::encrypt( $args['aws_secret'] ) );
 			update_post_meta( $server_id, 'wpcd_wpapp_backup_aws_bucket', $args['aws_bucket'] );
 			update_post_meta( $server_id, 'wpcd_wpapp_backup_aws_region', $args['aws_region'] );
+			update_post_meta( $server_id, 'wpcd_wpapp_backup_s3_endpoint', $args['s3_endpoint'] );
 
 		} elseif ( empty( $args['aws_key'] ) && empty( $args['aws_secret'] ) && empty( $args['aws_bucket'] ) ) {
 
@@ -657,6 +678,7 @@ class WPCD_WORDPRESS_TABS_SERVER_BACKUP extends WPCD_WORDPRESS_TABS {
 			delete_post_meta( $server_id, 'wpcd_wpapp_backup_aws_secret' );
 			delete_post_meta( $server_id, 'wpcd_wpapp_backup_aws_bucket' );
 			delete_post_meta( $server_id, 'wpcd_wpapp_backup_aws_region' );
+			delete_post_meta( $server_id, 'wpcd_wpapp_backup_s3_endpoint' );
 
 		} else {
 			// something ambiguous - let user know...

--- a/includes/core/apps/wordpress-app/tabs-server/backup.php
+++ b/includes/core/apps/wordpress-app/tabs-server/backup.php
@@ -249,7 +249,7 @@ class WPCD_WORDPRESS_TABS_SERVER_BACKUP extends WPCD_WORDPRESS_TABS {
 				// the id.
 				'data-wpcd-id'                  => $id,
 				// fields that contribute data for this action.
-				'data-wpcd-fields'              => wp_json_encode( array( '#wpcd_app_aws_key', '#wpcd_app_aws_secret', '#wpcd_app_aws_bucket', '#wpcd_app_aws_region' ) ),
+				'data-wpcd-fields'              => wp_json_encode( array( '#wpcd_app_aws_key', '#wpcd_app_aws_secret', '#wpcd_app_aws_bucket', '#wpcd_app_aws_region', '#wpcd_app_s3_endpoint' ) ),
 				// make sure we give the user a confirmation prompt.
 				'data-wpcd-confirmation-prompt' => __( 'Are you sure you would like to save these credentials?', 'wpcd' ),
 			),

--- a/includes/core/apps/wordpress-app/tabs/theme-and-plugin-updates.php
+++ b/includes/core/apps/wordpress-app/tabs/theme-and-plugin-updates.php
@@ -248,6 +248,7 @@ class WPCD_WORDPRESS_TABS_THEME_AND_PLUGIN_UPDATES extends WPCD_WORDPRESS_TABS {
 		$key    = $creds['aws_access_key_id'];
 		$secret = $creds['aws_secret_access_key'];
 		$bucket = $creds['aws_bucket_name'];
+		$endpoint = $creds['s3_endpoint'];
 
 		// Now, fill in all the other items that the bash script needs to run properly.
 		$args['update_type']      = '1';

--- a/includes/core/apps/wordpress-app/traits/traits-for-class-wordpress-app/backup.php
+++ b/includes/core/apps/wordpress-app/traits/traits-for-class-wordpress-app/backup.php
@@ -23,6 +23,7 @@ trait wpcd_wpapp_backup_functions {
 		$creds['aws_secret_access_key'] = 'unknown';
 		$creds['aws_bucket_name']       = '';
 		$creds['aws_region']            = '';
+		$creds['s3_endpoint']            = '';
 
 		// Get data from the current server.
 		$key    = $this->get_server_meta_by_app_id( $id, 'wpcd_wpapp_backup_aws_key', true );
@@ -45,7 +46,11 @@ trait wpcd_wpapp_backup_functions {
 		if ( empty( $region ) ) {
 			$region = wpcd_get_option( 'wordpress_app_aws_region' );
 		}
-		// If region is still empty default to us-east-1.
+		// if endpoint is empty on the app, use global endpoint.
+		if ( empty( $endpoint ) ) {
+			$endpoint = wpcd_get_option( 'wordpress_app_s3_endpoint' );
+		}
+		// If region is still empty default to us-east-1, unless endpoint is set.
 		if ( empty( $region ) ) {
 			$region = 'us-east-1';
 		}
@@ -55,13 +60,13 @@ trait wpcd_wpapp_backup_functions {
 		$creds['aws_secret_access_key'] = escapeshellarg( $secret );
 		$creds['aws_bucket_name']       = escapeshellarg( $bucket );
 		$creds['aws_region']            = escapeshellarg( $region );
-		$creds['s3_endpoint']            = escapeshellarg( $s3_endpoint );
+		$creds['s3_endpoint']            = escapeshellarg( $endpoint );
 
 		$creds['aws_access_key_id_noesc']     = $key;
 		$creds['aws_secret_access_key_noesc'] = $secret;
 		$creds['aws_bucket_name_noesc']       = $bucket;
 		$creds['aws_region_noesc']            = $region;
-		$creds['s3_endpoint_noesc']            = $s3_endpoint;
+		$creds['s3_endpoint_noesc']            = $endpoint;
 
 		return $creds;
 

--- a/includes/core/apps/wordpress-app/traits/traits-for-class-wordpress-app/backup.php
+++ b/includes/core/apps/wordpress-app/traits/traits-for-class-wordpress-app/backup.php
@@ -29,6 +29,7 @@ trait wpcd_wpapp_backup_functions {
 		$secret = self::decrypt( $this->get_server_meta_by_app_id( $id, 'wpcd_wpapp_backup_aws_secret', true ) );
 		$bucket = $this->get_server_meta_by_app_id( $id, 'wpcd_wpapp_backup_aws_bucket', true );
 		$region = $this->get_server_meta_by_app_id( $id, 'wpcd_wpapp_backup_aws_region', true );
+		$endpoint = $this->get_server_meta_by_app_id( $id, 'wpcd_wpapp_backup_s3_endpoint', true );
 
 		// If keys are empty on the app, use global keys.
 		if ( empty( $key ) ) {
@@ -54,11 +55,13 @@ trait wpcd_wpapp_backup_functions {
 		$creds['aws_secret_access_key'] = escapeshellarg( $secret );
 		$creds['aws_bucket_name']       = escapeshellarg( $bucket );
 		$creds['aws_region']            = escapeshellarg( $region );
+		$creds['s3_endpoint']            = escapeshellarg( $s3_endpoint );
 
 		$creds['aws_access_key_id_noesc']     = $key;
 		$creds['aws_secret_access_key_noesc'] = $secret;
 		$creds['aws_bucket_name_noesc']       = $bucket;
 		$creds['aws_region_noesc']            = $region;
+		$creds['s3_endpoint_noesc']            = $s3_endpoint;
 
 		return $creds;
 


### PR DESCRIPTION
Enabling custom S3 Endpoints in the standard backup scripts/configurations opens up the door to a slew of new providers beyond Amazon AWS S3.

These changes were specifically tested with the Backblaze S3 storage API, and confirmed to work, at least as far as creating a backup is concerned.

I'm still a bit fuzzy on the correlation between local backups and remote backup in the restore function, so that might need a bit more work.

I also may have been a bit too generous with where all the new s3_endpoint variable is being included, as it's not relevant to save it to the local server `credentials` file, at the moment anyway. This might be relevant if paired with a solution such as https://github.com/wbingli/awscli-plugin-endpoint in the future, but I opted to use the aws-cli `--endpoint-url=` parameter for now.