### PR TITLE
Feat: Allow updating with git-updater

### DIFF
--- a/wpcd.php
+++ b/wpcd.php
@@ -10,6 +10,7 @@ Item Id: 1493
 Author: WPCloudDeploy
 Author URI: https://wpclouddeploy.com
 Domain Path: /languages
+GitHub Plugin URI: WPCloudDeploy/wp-cloud-deploy
  */
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 

--- a/wpcd.php
+++ b/wpcd.php
@@ -11,6 +11,7 @@ Author: WPCloudDeploy
 Author URI: https://wpclouddeploy.com
 Domain Path: /languages
 GitHub Plugin URI: WPCloudDeploy/wp-cloud-deploy
+Primary Branch: main
  */
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 


### PR DESCRIPTION
Adds GitHub Plugin URI to plugin header to allow for optionally tracking with the development of the plugin on github and updating directly from the WordPress backend.

See: https://github.com/afragen/git-updater