### PR TITLE
Allow for ARM64 AWS CLI

### DIFF
--- a/includes/core/apps/wordpress-app/scripts/v1/raw/01-prepare_server.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/raw/01-prepare_server.txt
@@ -868,13 +868,19 @@ wp cli update --yes --allow-root  > /dev/null 2>&1
 
 
 # if aws cli is not present, install it
-if ! hash aws2 2>/dev/null
-then
+if ! hash aws2 2>/dev/null; then
 	echo $(date): "Getting and installing AWS CLI..."
-	wget "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip"  > /dev/null 2>&1
-	unzip awscli-exe-linux-x86_64.zip  > /dev/null 2>&1
+	# detect if we are on an ARM or x86_64 system
+	if [ "$(uname -m)" = "aarch64" ]; then
+		# ARM
+		curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"  > /dev/null 2>&1
+	else
+		# x86_64
+		curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"  > /dev/null 2>&1
+	fi
+	unzip awscliv2.zip  > /dev/null 2>&1
 	./aws/install  > /dev/null 2>&1
-	rm -rf aws awscli-exe-linux-x86_64.zip  > /dev/null 2>&1
+	rm -rf aws awscliv2.zip  > /dev/null 2>&1
 fi
 
 # Make sure update-notifier is installed - weirdly some vms/containers don't have this installed.


### PR DESCRIPTION
This patch detects if we're running on an ARM server and grabs the appropriate AWS CLI version from the official Amazon repository.

Admittedly, I switched both AWS CLI sources to the official Amazon URLs. Not sure why there was a different CloudFront URL there...